### PR TITLE
Extend font sizes for better visibility on 4k display

### DIFF
--- a/src/SettingsFont.as
+++ b/src/SettingsFont.as
@@ -59,7 +59,7 @@ void RenderSettingsFontName()
 
 void RenderSettingsFontSize()
 {
-	const array<int> availableSizes = { 16, 18, 20, 22 };
+	const array<int> availableSizes = { 16, 18, 20, 22, 24, 26, 28, 30 };
 
 	if (UI::BeginCombo("Font size", tostring(Setting_FontSize))) {
 		for (uint i = 0; i < availableSizes.Length; i++) {


### PR DESCRIPTION
For me the font size is quite small even on the highest setting on my 32" 4k monitor so i added font sizes up to 30 which should be enough