### PR TITLE
Tweaked link parsing and displaying

### DIFF
--- a/src/ChatLine.as
+++ b/src/ChatLine.as
@@ -349,6 +349,8 @@ class ChatLine
 		//                           ^^^
 		// $l[https://openplanet.nl/]yes$zyes
 		//                           ^^^
+		// $l [https://openplanet.nl/] yes$zyes
+		//                             ^^^
 		int index = text.IndexOfI("$l");
 		if (index == -1) {
 			AddElement(ElementText(text));
@@ -364,7 +366,7 @@ class ChatLine
 
 			// Parse link start
 			string textWithLink = text.SubStr(index);
-			auto parse = Regex::Search(textWithLink, "^\\$[lL](\\[[^\\]]+\\])?(.*?)(\\$[lLzZ>]|$)");
+			auto parse = Regex::Search(textWithLink, "^\\$[lL]\\s*(\\[[^\\]]+\\])?\\s*(.*?)(\\$[lLzZ>]|$)");
 			if (parse.Length == 0) {
 				// Invalid link?
 				warn("Invalid link in text: \"" + text + "\"");

--- a/src/Elements/Link.as
+++ b/src/Elements/Link.as
@@ -6,9 +6,9 @@ class ElementLink : Element
 	ElementLink(const string &in text, const string &in url)
 	{
 		m_text = ColoredString(text);
-		m_url = url;
+		m_url = url.Trim().ToLower();
 
-		if (!m_url.StartsWith("https://") && !m_url.StartsWith("http://")) {
+		if (!Regex::Contains(m_url, "^https?://")) {
 			m_url = "https://" + m_url;
 		}
 


### PR DESCRIPTION
Fixes #32 

- Trims the link and converts it to lowercase before checking whether it has a prefix
- The regex matches either `http://` or `https://`
- Modified link-parsing regex to make it allow for whitespaces without breaking