### PR TITLE
Fix #44 -- cache unsent chat msgs when input loses focus

### DIFF
--- a/src/ChatWindow.as
+++ b/src/ChatWindow.as
@@ -674,8 +674,10 @@ class ChatWindow : BetterChat::IChatMessageListener
 			// Workaround: https://github.com/ocornut/imgui/issues/2620#issuecomment-501136289
 			if (UI::IsItemDeactivated() && UI::IsKeyPressed(UI::Key::Escape)) {
 				shouldHideInput = true;
-				// UI::InputText will return "" when Esc is pressed, so let's restore the cached input value
-				m_input = m_lastInput;
+				if (Setting_CacheDraftOnEsc) {
+					// UI::InputText will return "" when Esc is pressed, so let's restore the cached input value
+					m_input = m_lastInput;
+				}
 			}
 
 			UI::PopStyleColor();

--- a/src/ChatWindow.as
+++ b/src/ChatWindow.as
@@ -683,6 +683,36 @@ class ChatWindow : BetterChat::IChatMessageListener
 			UI::PopStyleColor();
 			UI::PopItemWidth();
 			UI::End();
+
+			if (Setting_ObviousChat && !m_big) {
+				// draw a duplication of the InputText in the middle of the screen.
+				float sw = Draw::GetWidth();
+				float sh = Draw::GetHeight();
+				float w = sw/4.;
+				float h = sh/5.;
+
+				UI::SetNextWindowPos(
+					int(sw / 2.0f - w / 2.0f),
+					int(sh / 2.0f - h / 2.0f),
+					UI::Cond::Always
+				);
+				UI::SetNextWindowSize(int(w), int(h), UI::Cond::Always);
+
+				UI::Begin("BC-ObviousChatInput", UI::WindowFlags::NoTitleBar
+					| UI::WindowFlags::NoDecoration
+					| UI::WindowFlags::NoSavedSettings
+					| UI::WindowFlags::NoInputs
+					| UI::WindowFlags::NoFocusOnAppearing );
+
+				UI::PushFont(g_fontObviousChat);
+				// UI::PushStyleColor(UI::Col::FrameBg, vec4(0, 0, 0, 0));
+				UI::Text("CHAT FOCUSED!");
+				UI::Text("> ");
+				UI::TextWrapped(m_input);
+				UI::PopFont();
+
+				UI::End();
+			}
 		}
 
 		UI::PopStyleColor();

--- a/src/ChatWindow.as
+++ b/src/ChatWindow.as
@@ -11,6 +11,7 @@ class ChatWindow : BetterChat::IChatMessageListener
 	bool m_showInput = false;
 	bool m_focusOnInput = false;
 	string m_input;
+	string m_lastInput;
 	int m_setInputCursor = -1;
 
 	float m_chatLineFrameHeight = 30.0f;
@@ -89,7 +90,8 @@ class ChatWindow : BetterChat::IChatMessageListener
 	void HideInput()
 	{
 		m_showInput = false;
-		m_input = "";
+		// m_input = "";
+		// trace("[HideInput] m_input = `" + m_input + "`");
 	}
 
 	void AddSystemLine(const string &in line)
@@ -189,7 +191,7 @@ class ChatWindow : BetterChat::IChatMessageListener
 
 			if (IsVisible()) {
 				if (key == Setting_KeyInput1 || key == Setting_KeyInput2) {
-					ShowInput();
+					ShowInput(m_input);
 					return UI::InputBlocking::Block;
 				} else if (key == Setting_KeyInputTeam) {
 					ShowInput("/t ");
@@ -234,6 +236,7 @@ class ChatWindow : BetterChat::IChatMessageListener
 
 	void InputCallback(UI::InputTextCallbackData@ data)
 	{
+		trace("[InputCallback|Start] m_input = `" + m_input + "`");
 		if (data.EventFlag == UI::InputTextFlags::CallbackAlways) {
 			m_auto.Update(data);
 
@@ -286,6 +289,7 @@ class ChatWindow : BetterChat::IChatMessageListener
 				}
 			}
 		}
+		trace("[InputCallback|End] m_input = `" + m_input + "`");
 	}
 
 	void Update(float dt)
@@ -646,7 +650,9 @@ class ChatWindow : BetterChat::IChatMessageListener
 				UI::SetKeyboardFocusHere();
 				m_focusOnInput = false;
 			}
+			trace("[Render1] m_input = `" + m_input + "`");
 			UI::PushFont(g_fontChat);
+			m_lastInput = m_input;
 			m_input = UI::InputText("##ChatInput", m_input, pressedEnter,
 				UI::InputTextFlags::EnterReturnsTrue |
 				UI::InputTextFlags::CallbackAlways |
@@ -656,6 +662,7 @@ class ChatWindow : BetterChat::IChatMessageListener
 				UI::InputTextCallback(InputCallback)
 			);
 			UI::PopFont();
+			trace("[Render2] m_input = `" + m_input + "`");
 
 			if (pressedEnter) {
 				if (m_auto.IsVisible()) {
@@ -663,6 +670,8 @@ class ChatWindow : BetterChat::IChatMessageListener
 					m_focusOnInput = true;
 				} else {
 					OnUserInput(m_input);
+					trace("set m_input='' since chat message was sent.");
+					m_input = "";
 					shouldHideInput = true;
 				}
 			}
@@ -671,6 +680,8 @@ class ChatWindow : BetterChat::IChatMessageListener
 			// Workaround: https://github.com/ocornut/imgui/issues/2620#issuecomment-501136289
 			if (UI::IsItemDeactivated() && UI::IsKeyPressed(UI::Key::Escape)) {
 				shouldHideInput = true;
+				// UI::InputText will return "" when Esc is pressed, so let's restore the cached input value
+				m_input = m_lastInput;
 			}
 
 			UI::PopStyleColor();
@@ -689,7 +700,9 @@ class ChatWindow : BetterChat::IChatMessageListener
 		}
 
 		if (shouldHideInput) {
+			// m_input already set to '' by now
 			HideInput();
+			trace("[HideInput] m_input = `" + m_input + "`");
 		}
 	}
 }

--- a/src/ChatWindow.as
+++ b/src/ChatWindow.as
@@ -90,8 +90,6 @@ class ChatWindow : BetterChat::IChatMessageListener
 	void HideInput()
 	{
 		m_showInput = false;
-		// m_input = "";
-		// trace("[HideInput] m_input = `" + m_input + "`");
 	}
 
 	void AddSystemLine(const string &in line)
@@ -236,7 +234,6 @@ class ChatWindow : BetterChat::IChatMessageListener
 
 	void InputCallback(UI::InputTextCallbackData@ data)
 	{
-		trace("[InputCallback|Start] m_input = `" + m_input + "`");
 		if (data.EventFlag == UI::InputTextFlags::CallbackAlways) {
 			m_auto.Update(data);
 
@@ -289,7 +286,6 @@ class ChatWindow : BetterChat::IChatMessageListener
 				}
 			}
 		}
-		trace("[InputCallback|End] m_input = `" + m_input + "`");
 	}
 
 	void Update(float dt)
@@ -650,7 +646,6 @@ class ChatWindow : BetterChat::IChatMessageListener
 				UI::SetKeyboardFocusHere();
 				m_focusOnInput = false;
 			}
-			trace("[Render1] m_input = `" + m_input + "`");
 			UI::PushFont(g_fontChat);
 			m_lastInput = m_input;
 			m_input = UI::InputText("##ChatInput", m_input, pressedEnter,
@@ -662,7 +657,6 @@ class ChatWindow : BetterChat::IChatMessageListener
 				UI::InputTextCallback(InputCallback)
 			);
 			UI::PopFont();
-			trace("[Render2] m_input = `" + m_input + "`");
 
 			if (pressedEnter) {
 				if (m_auto.IsVisible()) {
@@ -670,7 +664,7 @@ class ChatWindow : BetterChat::IChatMessageListener
 					m_focusOnInput = true;
 				} else {
 					OnUserInput(m_input);
-					trace("set m_input='' since chat message was sent.");
+					// reset m_input since chat message was sent.
 					m_input = "";
 					shouldHideInput = true;
 				}
@@ -700,9 +694,7 @@ class ChatWindow : BetterChat::IChatMessageListener
 		}
 
 		if (shouldHideInput) {
-			// m_input already set to '' by now
 			HideInput();
-			trace("[HideInput] m_input = `" + m_input + "`");
 		}
 	}
 }

--- a/src/ChatWindow.as
+++ b/src/ChatWindow.as
@@ -683,36 +683,6 @@ class ChatWindow : BetterChat::IChatMessageListener
 			UI::PopStyleColor();
 			UI::PopItemWidth();
 			UI::End();
-
-			if (Setting_ObviousChat && !m_big) {
-				// draw a duplication of the InputText in the middle of the screen.
-				float sw = Draw::GetWidth();
-				float sh = Draw::GetHeight();
-				float w = sw/4.;
-				float h = sh/5.;
-
-				UI::SetNextWindowPos(
-					int(sw / 2.0f - w / 2.0f),
-					int(sh / 2.0f - h / 2.0f),
-					UI::Cond::Always
-				);
-				UI::SetNextWindowSize(int(w), int(h), UI::Cond::Always);
-
-				UI::Begin("BC-ObviousChatInput", UI::WindowFlags::NoTitleBar
-					| UI::WindowFlags::NoDecoration
-					| UI::WindowFlags::NoSavedSettings
-					| UI::WindowFlags::NoInputs
-					| UI::WindowFlags::NoFocusOnAppearing );
-
-				UI::PushFont(g_fontObviousChat);
-				// UI::PushStyleColor(UI::Col::FrameBg, vec4(0, 0, 0, 0));
-				UI::Text("CHAT FOCUSED!");
-				UI::Text("> ");
-				UI::TextWrapped(m_input);
-				UI::PopFont();
-
-				UI::End();
-			}
 		}
 
 		UI::PopStyleColor();

--- a/src/Settings.as
+++ b/src/Settings.as
@@ -117,6 +117,9 @@ bool Setting_SoundFavorite = true;
 [Setting category="Messages" name="Sound volume" min=0 max=1]
 float Setting_SoundGain = 0.15f;
 
+[Setting category="Messages" name="Cache draft messages on <Esc>" description="If Enabled: When a chat message has been drafted, if <Esc> is used to defocus chat then the draft will be kept for next time. Drafted means: written and not yet sent."]
+bool Setting_CacheDraftOnEsc = false;
+
 
 
 enum BackgroundStyle

--- a/src/Settings.as
+++ b/src/Settings.as
@@ -154,9 +154,6 @@ bool Setting_ShowScrollbar = true;
 [Setting category="Appearance" name="Empty space before first lines"]
 bool Setting_FirstLineEmptySpace = true;
 
-[Setting category="Appearance" name="Obvious Chat Input" description="When chat input is focused (i.e., you can type a chat msg), this option makes it VERY obvious. Use this option to prevent accidentally being in chat mode at the start of a race."]
-bool Setting_ObviousChat = true;
-
 
 
 [Setting category="Colors" name="System color" color]

--- a/src/Settings.as
+++ b/src/Settings.as
@@ -154,6 +154,9 @@ bool Setting_ShowScrollbar = true;
 [Setting category="Appearance" name="Empty space before first lines"]
 bool Setting_FirstLineEmptySpace = true;
 
+[Setting category="Appearance" name="Obvious Chat Input" description="When chat input is focused (i.e., you can type a chat msg), this option makes it VERY obvious. Use this option to prevent accidentally being in chat mode at the start of a race."]
+bool Setting_ObviousChat = true;
+
 
 
 [Setting category="Colors" name="System color" color]

--- a/src/main.as
+++ b/src/main.as
@@ -2,6 +2,7 @@ ChatWindow g_window;
 
 Resources::Font@ g_fontHeader;
 Resources::Font@ g_fontChat;
+Resources::Font@ g_fontObviousChat;
 
 void Update(float dt)
 {
@@ -92,6 +93,7 @@ void Main()
 	Commands::Load();
 
 	@g_fontHeader = Resources::GetFont("DroidSans-Bold.ttf", 22);
+	@g_fontObviousChat = @g_fontHeader;
 
 	if (Setting_FontName != "DroidSans.ttf" || Setting_FontSize != 16) {
 		@g_fontChat = Resources::GetFont(Setting_FontName, Setting_FontSize, -1, -1, true, true, true);

--- a/src/main.as
+++ b/src/main.as
@@ -2,7 +2,6 @@ ChatWindow g_window;
 
 Resources::Font@ g_fontHeader;
 Resources::Font@ g_fontChat;
-Resources::Font@ g_fontObviousChat;
 
 void Update(float dt)
 {
@@ -93,7 +92,6 @@ void Main()
 	Commands::Load();
 
 	@g_fontHeader = Resources::GetFont("DroidSans-Bold.ttf", 22);
-	@g_fontObviousChat = @g_fontHeader;
 
 	if (Setting_FontName != "DroidSans.ttf" || Setting_FontSize != 16) {
 		@g_fontChat = Resources::GetFont(Setting_FontName, Setting_FontSize, -1, -1, true, true, true);


### PR DESCRIPTION
Fix #44 -- cache unsent chat msgs when input loses focus

Implementation is very simple, hopefully it speaks for itself.
I've tested it today on COTD and Super Royal -- seems to work as intended.

