### PR TITLE
Add chat channel API

### DIFF
--- a/src/ChatChannel.as
+++ b/src/ChatChannel.as
@@ -1,0 +1,58 @@
+
+class ChatChannel {
+    string m_title;
+    BetterChat::IChatChannelSink@ m_sink;
+
+    array<ChatLine@> m_lines;
+
+	uint64 m_lastMessageTime = 0;
+
+    ChatChannel() {}
+
+    ChatChannel(const string&in title, BetterChat::IChatChannelSink@ sink) {
+        m_title = title;
+        @m_sink = sink;
+    }
+
+    void Clear()
+	{
+		m_lines.RemoveRange(0, m_lines.Length);
+	}
+
+    string GetTitle() {
+        return m_title;
+    }
+
+    void SendChatMessage(const string&in text) {
+        if (@m_sink !is null) {
+            m_sink.SendChatMessage(text);
+        }
+    }
+
+    void InsertLine(ChatLine@ line) {
+        m_lines.InsertLast(line);
+
+		if (m_lines.Length > uint(Setting_MaximumLines)) {
+			m_lines.RemoveRange(0, m_lines.Length - Setting_MaximumLines);
+		}
+
+        // Remember when the last message was received
+		m_lastMessageTime = Time::Now;
+    }
+}
+
+class ChatChannelHook: BetterChat::IChatChannelHook {
+    ChatChannel@ m_channel;
+
+    ChatChannelHook(ChatChannel@ channel) {
+        @m_channel = channel;
+    }
+
+    void Clear() override {
+        m_channel.Clear();
+    }
+
+	void AddChatEntry(BetterChat::ChatEntry entry) override {
+        g_window.AddChatLine(ChatLine(g_window.NextLineId(), Time::Stamp, entry), m_channel);
+    }
+}

--- a/src/ChatLine.as
+++ b/src/ChatLine.as
@@ -45,6 +45,12 @@ class ChatLine
 	}
 #endif
 
+	ChatLine(uint id, int64 time, BetterChat::ChatEntry entry) {
+		m_id = id;
+		m_time = time;
+		FromSharedEntry(entry);
+	}
+
 	vec4 GetHighlightColor(const vec4 &in def = vec4(0, 0, 0, 1))
 	{
 		vec3 ret(def.x, def.y, def.z);
@@ -89,6 +95,14 @@ class ChatLine
 		FromChatLineInfo(ChatLineInfo(line));
 	}
 #endif
+
+	void FromSharedEntry(BetterChat::ChatEntry entry) {
+		// Trace the message to the log if needed by settings (and not in streamer mode)
+		if (Setting_TraceToLog && !Setting_StreamerMode) {
+			trace(entry.m_authorName + ", " + entry.m_text);
+		}
+		FromChatLineInfo(ChatLineInfo(entry));
+	}
 
 	void FromChatLineInfo(const ChatLineInfo &in info)
 	{

--- a/src/ChatLineInfo.as
+++ b/src/ChatLineInfo.as
@@ -33,6 +33,36 @@ class ChatLineInfo
 
 	string m_text;
 
+	ChatLineInfo(BetterChat::ChatEntry entry) {
+		FromSharedEntry(entry);
+	}
+
+	void FromSharedEntry(BetterChat::ChatEntry entry) {
+		m_text = entry.m_text;
+		m_authorName = entry.m_authorName;
+		m_authorClubTag = entry.m_clubTag;
+		m_overrideClubTag = entry.m_clubTag != "";
+		m_teamColorText = entry.m_teamColor;
+		m_teamNumber = entry.m_teamColor != "" ? 1 : 0;
+		m_isSystem = entry.m_system;
+		m_scope = FromSharedScope(entry.m_scope);
+	}
+
+	ChatLineScope FromSharedScope(BetterChat::ChatEntryScope scope) {
+		switch (scope) {
+			case BetterChat::ChatEntryScope::Everyone:
+				return ChatLineScope::Everyone;
+			case BetterChat::ChatEntryScope::SpectatorCurrent:
+				return ChatLineScope::SpectatorCurrent;
+			case BetterChat::ChatEntryScope::SpectatorAll:
+				return ChatLineScope::SpectatorAll;
+			case BetterChat::ChatEntryScope::Team:
+				return ChatLineScope::Team;
+			default:
+				return ChatLineScope::YouOnly;
+		}
+	}
+
 #if TMNEXT
 	ChatLineInfo(NGameScriptChat_SEntry@ entry)
 	{

--- a/src/Export.as
+++ b/src/Export.as
@@ -33,4 +33,10 @@ namespace BetterChat
 
 	// Sends a message to the server.
 	import void SendChatMessage(const string &in text) from "BetterChat";
+
+	// Registers a new chat channel.
+	import IChatChannelHook@ AquireChatChannelHook(const string&in title, IChatChannelSink@ sink) from "BetterChat";
+
+	// Unregisters a chat channel.
+	import void ReleaseChatChannelHook(IChatChannelHook@ hook) from "BetterChat";
 }

--- a/src/ExportCode.as
+++ b/src/ExportCode.as
@@ -43,23 +43,15 @@ namespace BetterChat
 
 	void SendChatMessage(const string &in text)
 	{
-#if TMNEXT
-		if (!Permissions::InGameChat()) {
-			return;
-		}
-#endif
+		g_window.SendChatMessage(text);
+	}
 
-		auto pg = GetApp().CurrentPlayground;
-		if (pg is null) {
-			//TODO: Queue the message for later
-			warn("Can't send message right now because there's no playground!");
-			return;
-		}
-
-		if (text.Length > 2000) {
-			pg.Interface.ChatEntry = text.SubStr(0, 2000) + " (...)";
-		} else {
-			pg.Interface.ChatEntry = text;
-		}
+	IChatChannelHook@ AquireChatChannelHook(const string&in title, IChatChannelSink@ sink) {
+		auto channel = ChatChannel(title, sink);
+		g_window.AddChannel(channel);
+		return ChatChannelHook(channel);
+	}
+	void ReleaseChatChannelHook(IChatChannelHook@ hook) {
+		g_window.RemoveChannel(cast<ChatChannelHook@>(hook).m_channel);
 	}
 }

--- a/src/ExportShared.as
+++ b/src/ExportShared.as
@@ -24,4 +24,43 @@ namespace BetterChat
 		void OnChatMessage(const string &in line);
 #endif
 	}
+
+	shared interface IChatChannelHook
+	{
+		void AddChatEntry(ChatEntry entry);
+		void Clear();
+	}
+
+	shared interface IChatChannelSink
+	{
+		void SendChatMessage(const string&in text);
+	}
+
+	shared class ChatEntry {
+		string m_text;
+		string m_authorName;
+		string m_clubTag;
+		string m_teamColor;
+		bool m_system;
+		ChatEntryScope m_scope;
+
+		ChatEntry() {}
+
+		ChatEntry(const string&in text, const string&in authorName, const string&in clubTag = "", const string&in teamColor = "", bool system = false, ChatEntryScope scope = BetterChat::ChatEntryScope::Everyone) {
+			m_text = text;
+			m_authorName = authorName;
+			m_clubTag = clubTag;
+			m_teamColor = teamColor;
+			m_system = system;
+			m_scope = scope;
+		}
+	}
+
+	shared enum ChatEntryScope {
+		Everyone,
+		SpectatorCurrent,
+		SpectatorAll,
+		Team,
+		YouOnly,
+	}
 }

--- a/src/ServerChat.as
+++ b/src/ServerChat.as
@@ -1,0 +1,36 @@
+
+class ChatMessageSink: BetterChat::IChatChannelSink {
+    void SendChatMessage(const string&in text) override {
+#if TMNEXT
+		if (!Permissions::InGameChat()) {
+			return;
+		}
+#endif
+
+		auto pg = GetApp().CurrentPlayground;
+		if (pg is null) {
+			//TODO: Queue the message for later
+			warn("Can't send message right now because there's no playground!");
+			return;
+		}
+
+		if (text.Length > 2000) {
+			pg.Interface.ChatEntry = text.SubStr(0, 2000) + " (...)";
+		} else {
+			pg.Interface.ChatEntry = text;
+		}
+    }
+}
+
+// Useful for debugging purposes
+class EchoSink: BetterChat::IChatChannelSink {
+    BetterChat::IChatChannelHook@ m_hook;
+
+    void SetHook(BetterChat::IChatChannelHook@ hook) {
+        @m_hook = hook;
+    }
+
+    void SendChatMessage(const string&in text) override {
+        m_hook.AddChatEntry(BetterChat::ChatEntry(text, "", "", "", true));
+    }
+}


### PR DESCRIPTION
Draft implementation of #65. Quite a lot of changes to break out the initial assumption of BC that only one message destination exists. The draft UI uses tab-like buttons to switch between different chat channels. For the most part, each channel should be isolated, which means some relevant structures have been moved to a `ChatChannel` class.

This is not completely ready, but I'm submitting it at this stage to get a review on what's been done so far. Implementation is mostly done apart from correctly handling Listeners.